### PR TITLE
add responsive breakpoints to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,13 +13,13 @@ import "@styles/global.css";
   <body class="bg-[#f6f6f5]">
 
     <!-- Main section -->
-    <section class="flex flex-col items-center pt-28 overflow-hidden">
+    <section class="flex flex-col items-center pt-16 sm:pt-20 md:pt-28 overflow-hidden">
 
       <!-- Inner content -->
-      <div class="relative z-10 flex flex-col items-center gap-16 max-w-3xl mx-auto px-6 text-center pb-16">
+      <div class="relative z-10 flex flex-col items-center gap-8 sm:gap-12 md:gap-16 max-w-3xl mx-auto px-6 text-center pb-16">
 
         <!-- Logo icon -->
-        <svg xmlns="http://www.w3.org/2000/svg" width="80" height="47" viewBox="0 0 80 47" fill="none">
+        <svg xmlns="http://www.w3.org/2000/svg" width="80" height="47" viewBox="0 0 80 47" fill="none" class="w-14 sm:w-16 md:w-20 h-auto">
             <g clip-path="url(#clip0_8931_62026)">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M38.9729 6.11659L39.6074 6.75579L40.2426 6.11659C43.9632 2.37269 48.309 0.120828 52.8515 0.118158C55.3637 0.104578 57.8235 0.841988 59.9188 2.23696C62.0163 3.63344 63.654 5.62587 64.6236 7.96108L64.625 7.96441L64.6264 7.96776C67.098 13.9649 64.7984 20.4569 59.6437 25.6473L39.5968 45.82L19.5605 25.6479C16.7205 22.7899 14.7446 19.6291 13.9113 16.2033C13.1964 13.4188 13.3845 10.477 14.4486 7.80738L14.4567 7.78687L14.4652 7.76651C15.433 5.44852 17.0641 3.47265 19.1511 2.09031C21.2348 0.710168 23.6789 -0.0160206 26.1732 0.00371044C30.7736 0.00763244 35.1865 2.30639 38.9729 6.11659ZM24.7352 37.624C24.7372 37.6261 24.7392 37.6282 24.7413 37.6303L33.13 46.1243H12.8093C8.82477 46.1243 5.61674 45.0145 3.36277 43.0427C1.10079 41.0638 -0.00109863 38.3808 -0.00109863 35.7003C-0.00109863 33.2164 0.944291 30.7212 2.89953 28.7873C4.85419 26.8541 7.65868 25.6321 11.1538 25.3454L12.382 25.2447L19.5124 32.2969C19.8133 32.5758 20.2715 33.0442 24.7352 37.624ZM66.8096 25.2602L68.0347 25.3607C71.5298 25.6474 74.3343 26.8694 76.289 28.8026C78.2442 30.7365 79.1896 33.2317 79.1896 35.7156C79.1896 38.396 78.0877 41.0791 75.8257 43.058C73.5718 45.0298 70.3638 46.1396 66.3793 46.1396H46.0345L54.4233 37.6456L54.4358 37.6329L54.9993 37.0546C58.9071 33.0451 59.3608 32.5796 59.6591 32.3055L66.8096 25.2602Z" fill="#DE0AB0"/>
             </g>
@@ -30,9 +30,9 @@ import "@styles/global.css";
             </defs>
         </svg>
 
-        <h1 class="font-canela text-[#0c1d31] text-[60px] leading-17.5 tracking-[-1.5px] font-normal">CloudValid<br />is now part of Datum</h1>
+        <h1 class="font-canela text-[#0c1d31] text-[36px] sm:text-[48px] md:text-[60px] leading-tight sm:leading-tight md:leading-17.5 tracking-[-0.5px] sm:tracking-[-1px] md:tracking-[-1.5px] font-normal">CloudValid<br />is now part of Datum</h1>
 
-        <p class="text-[#0c1d31] text-center text-lg leading-6.5 tracking-[0] font-normal w-122">
+        <p class="text-[#0c1d31] text-center text-base sm:text-lg leading-6 sm:leading-6.5 tracking-[0] font-normal w-full md:w-122">
           We're excited to announce that CloudValid has joined Datum. As part of our commitment to the community, we're working towards open-sourcing our domain validation technology so developers everywhere can continue to build with confidence.
         </p>
 


### PR DESCRIPTION
Scale down heading, logo, spacing, and paragraph width for mobile and tablet viewports.